### PR TITLE
workaround "Error creating mount directory" errors at container startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v0.9.0
 * luks encryption support
+* fix (retry) mount error "mkdir - file exists"
 
 ## v0.8.0
 * fix did not umount when volume is broken

--- a/plugin.go
+++ b/plugin.go
@@ -260,7 +260,7 @@ func (d plugin) Mount(r *volume.MountRequest) (*volume.MountResponse, error) {
 
 	// Is it encrypted?
 	if result, err := isLuks(physdev); result == true {
-		logger.Debugf("Encrypted volume - using key file \"%s\"", d.config.EncryptionKey)
+		logger.Debugf("Encrypted volume - using key file '%s'", d.config.EncryptionKey)
 		// If yes, we must have a passphrase.
 		if d.config.EncryptionKey == "" {
 			logger.Errorf("Device %s is encrypted, and I have no pass to decrypt it.", physdev)
@@ -280,8 +280,8 @@ func (d plugin) Mount(r *volume.MountRequest) (*volume.MountResponse, error) {
 	}
 
 
-    //
-    // Check filesystem and format if needed
+	//
+	// Check filesystem and format if needed
 
 	fsType, err := getFilesystemType(dev)
 	if err != nil {
@@ -310,8 +310,10 @@ func (d plugin) Mount(r *volume.MountRequest) (*volume.MountResponse, error) {
 	// Mount device
 
 	path := filepath.Join(d.config.MountDir, r.Name)
-	if err = os.MkdirAll(path, 0700); err != nil {
-		logger.WithError(err).Error("Error creating mount directory")
+
+	err = createMountDir(path)
+	if err != nil {
+		logger.WithError(err).Errorf("Error creating mount directory %s", path)
 		return nil, err
 	}
 


### PR DESCRIPTION
Once in a while, we have containers startup errors like this:
`"VolumeDriver.Mount: mkdir /var/lib/cinder/mount/prometheus_promdata: file exists"`.
When it happens, the directory is actually already mounted, but in a strange state. To fix it, we have to umount it and retry.
This code does the umount/retry workaround automatically.